### PR TITLE
Exclude text emoji with emoji modifier in text_presentation

### DIFF
--- a/lib/unicode/emoji.rb
+++ b/lib/unicode/emoji.rb
@@ -48,7 +48,7 @@ module Unicode
 
     text_presentation_sequence = \
       join[
-        pack_and_join[TEXT_PRESENTATION]+ "(?!" + pack[EMOJI_VARIATION_SELECTOR] + ")" + pack[TEXT_VARIATION_SELECTOR] + "?",
+        pack_and_join[TEXT_PRESENTATION]+ "(?!" + pack_and_join[EMOJI_MODIFIERS + [EMOJI_VARIATION_SELECTOR]] + ")" + pack[TEXT_VARIATION_SELECTOR] + "?",
         pack_and_join[EMOJI_PRESENTATION] + pack[TEXT_VARIATION_SELECTOR]
       ]
 

--- a/spec/unicode_emoji_spec.rb
+++ b/spec/unicode_emoji_spec.rb
@@ -255,6 +255,11 @@ describe Unicode::Emoji do
       assert_nil $&
     end
 
+    it "does not match textual singleton emoji in combination with emoji modifiers" do
+      "✌🏻 victory hand" =~ Unicode::Emoji::REGEX_TEXT
+      assert_nil $&
+    end
+
     it "does not match singleton 'component' emoji codepoints" do
       "🏻 light skin tone" =~ Unicode::Emoji::REGEX_TEXT
       assert_nil $&


### PR DESCRIPTION
Notice that textual emojis with a modifier (ie: ✌🏻) is being matched by `REGEX_TEXT`.

Made some quick adjustment to the `text_presentation_sequence` to not match if the text emoji is followed by a emoji modifier. 