### PR TITLE
Relax `required_ruby_version` to support Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+        - '4.0'
         - '3.4'
         - '3.3'
         - '3.2'
@@ -21,7 +22,7 @@ jobs:
         - macos-latest
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -43,7 +44,7 @@ jobs:
         - '3.0'
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/unicode-emoji.gemspec
+++ b/unicode-emoji.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.metadata      = { "rubygems_mfa_required" => "true" }
 
-  gem.required_ruby_version = ">= 2.5", "< 4.0"
+  gem.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
This Pull Request relaxed the `required_ruby_version` to allow Ruby 4.0.

The current gemspec specifies an upper bound of "< 4.0", which prevents `gem install unicode-emoji` from working on Ruby 4.0, scheduled for release on December 25.
By removing this upper bound, the gem will continue to work on Ruby 4.0 and future Ruby versions.

- Ruby 4.0.0 preview2 Released
  - https://www.ruby-lang.org/en/news/2025/11/17/ruby-4-0-0-preview2-released/

### Update CI Matrix

This Pull Request also adds Ruby 4.0 to the CI matrix for the `test` jobs running on Ubuntu and macOS.
However, the `test-windows` job has not been updated, since Ruby 4.0 for `ruby/setup-ruby` on `windows-2025` has not yet been released.
