### PR TITLE
CI: Add Ruby 4.0 to the Windows CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+        - '4.0'
         - '3.4'
         - '3.3'
         - '3.2'


### PR DESCRIPTION
This Pull Request adds Ruby 4.0 to the Windows CI matrix.
It is a follow-up to #17, as Ruby 4.0 for Windows was not yet available in setup-ruby.